### PR TITLE
Add option to toggle all tooltip customizations

### DIFF
--- a/Datamine/Localization/enUS.lua
+++ b/Datamine/Localization/enUS.lua
@@ -60,6 +60,9 @@ L["CONFIG_HEADER_GOBJECT_TOOLTIPS"] = "Game Object Tooltips";
 L["CONFIG_TOOLTIP_KEY_COLOR_NAME"] = "Data Key Color";
 L["CONFIG_TOOLTIP_KEY_COLOR_TOOLTIP"] = "Color of the data keys on tooltips";
 
+L["CONFIG_TOOLTIP_ENABLE_NAME"] = "Enable Tooltip Info";
+L["CONFIG_TOOLTIP_ENABLE_TOOLTIP"] = "If enabled, adds extra information to most tooltips in-game";
+
 L["CONFIG_TOOLTIP_VALUE_COLOR_NAME"] = "Data Value Color";
 L["CONFIG_TOOLTIP_VALUE_COLOR_TOOLTIP"] = "Color of the data values on tooltips";
 

--- a/Datamine/Modules/Tooltips/Settings.lua
+++ b/Datamine/Modules/Tooltips/Settings.lua
@@ -8,6 +8,16 @@ local function CreateSubcategory(title)
     return Settings.RegisterVerticalLayoutSubcategory(category, title);
 end
 
+do -- if disabled, all tooltip customizations will be hidden
+    local variable = "TooltipEnableCustomizations";
+    local name = L.CONFIG_TOOLTIP_ENABLE_NAME;
+    local default = true;
+    local setting = S.RegisterSetting(category, variable, name, default);
+    local tooltip = L.CONFIG_TOOLTIP_ENABLE_TOOLTIP;
+
+    S.CreateCheckbox(category, setting, tooltip);
+end
+
 do
     local variable = "TooltipKeyColor";
     local name = L.CONFIG_TOOLTIP_KEY_COLOR_NAME;

--- a/Datamine/Modules/Tooltips/Tooltips.lua
+++ b/Datamine/Modules/Tooltips/Tooltips.lua
@@ -72,6 +72,10 @@ function Tooltips.ShouldShow(configKey)
         return true;
     end
 
+    if not S.GetSetting("TooltipEnableCustomizations") then
+        return false;
+    end
+
     if S.GetSetting("TooltipUseModifier") then
         if S.IsTooltipModifierDown() then
             return true;

--- a/Datamine/Settings/SettingsCore.lua
+++ b/Datamine/Settings/SettingsCore.lua
@@ -51,6 +51,12 @@ local function InitSavedVariables()
         DatamineConfig = CopyTable(defaultConfig);
     end
 
+    for k, v in pairs(defaultConfig) do
+        if DatamineConfig[k] == nil then
+            DatamineConfig[k] = v;
+        end
+    end
+
     for k, v in pairs(DatamineConfig) do
         local variable = k;
         local setting = Settings.GetSetting(variable);


### PR DESCRIPTION
It was a dark, foggy, and rainy night here in Texas when I was shown that it's a bit ridiculous that you can't just enable/disable all tooltip customizations with one click.

This remedies that. It currently doesn't lock out all the other options but it at least should help prevent anymore headaches caused by going through every tab one by one and unchecking the boxes.

Also fixes a minor bug relating to populating new variables into savedvars.

Fixes #24 