### PR TITLE
Fix UI size inconsistencies

### DIFF
--- a/Datamine/Modules/Unified/UnifiedUIMixins.lua
+++ b/Datamine/Modules/Unified/UnifiedUIMixins.lua
@@ -1011,13 +1011,15 @@ end
 
 -------------
 
-local DEFAULT_W = 1600;
-local DEFAULT_H = 900;
+local UI_SCALE = 0.65;
 
 DatamineUnifiedFrameMixin = {};
 
 function DatamineUnifiedFrameMixin:OnLoad()
-    self:SetSize(DEFAULT_W, DEFAULT_H);
+    local screenSize = C_VideoOptions.GetCurrentGameWindowSize();
+    screenSize:ScaleBy(UI_SCALE);
+
+    self:SetSize(screenSize:GetXY());
     self.TitleContainer.Text:SetText(L.ADDON_TITLE);
 
     Registry:RegisterCallback(Events.WORKSPACE_MODE_CHANGED, self.OnWorkspaceModeChanged, self);


### PR DESCRIPTION
Calculates the UI size based on the user's current game window size. Prevents those with very low resolution monitors from being completely overtaken and overwhelmed by the UI. Fixes #26 