### PR TITLE
Add achievement tooltips to achievement UI

### DIFF
--- a/Datamine/Modules/Tooltips/Tooltips.lua
+++ b/Datamine/Modules/Tooltips/Tooltips.lua
@@ -862,7 +862,7 @@ EventRegistry:RegisterCallback("AchievementFrameAchievement.OnEnter", OnAchievem
 EventRegistry:RegisterCallback("AchievementFrameAchievement.OnLeave", OnAchievementLeave);
 EventUtil.ContinueOnAddOnLoaded("Blizzard_AchievementUI", function() -- ensure the tooltips hide correctly when the achievement frame is closed
     AchievementFrame:HookScript("OnHide", function()
-        if GameTooltip:IsOwned(LAST_ACHIEVEMENT_TOOLTIP_OWNER) then
+        if LAST_ACHIEVEMENT_TOOLTIP_OWNER and GameTooltip:IsOwned(LAST_ACHIEVEMENT_TOOLTIP_OWNER) then
             GameTooltip:Hide();
             LAST_ACHIEVEMENT_TOOLTIP_OWNER = nil;
         end


### PR DESCRIPTION
Adds tooltips to achievement entries to show their ID, if such functionality is enabled. Does not work for the summary page because that page is a mess.

Fixes #32